### PR TITLE
feat: 27_Thymeleafを使ったReadの画面描画処理

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,10 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// Thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	// 便利機能、ユーティリティ
 	implementation 'org.apache.commons:commons-lang3:3.18.0'
 	//Lombok

--- a/src/main/java/raisetech/Student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/Student/management/controller/StudentController.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.Student.management.controller.converter.StudentConverter;
@@ -12,7 +14,7 @@ import raisetech.Student.management.data.StudentsCourses;
 import raisetech.Student.management.domain.StudentDetail;
 import raisetech.Student.management.service.StudentService;
 
-@RestController
+@Controller
 public class StudentController {
 
   private StudentService service;
@@ -25,11 +27,12 @@ public class StudentController {
   }
 
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() {
+  public String getStudentList(Model model) {
     List<Student> students = service.searchStudentList();
     List<StudentsCourses> studentsCourses = service.searchStudentCourseList();
 
-    return converter.convertStudentDetails(students, studentsCourses);
+    model.addAttribute("studentList", converter.convertStudentDetails(students, studentsCourses));
+    return "studentList";
   }
 
   @GetMapping("/studentCourseList")

--- a/src/main/java/raisetech/Student/management/data/Student.java
+++ b/src/main/java/raisetech/Student/management/data/Student.java
@@ -9,7 +9,7 @@ public class Student {
 
   private String id;
   private String name;
-  private String furigana;
+  private String kanaName;
   private String nickname;
   private String email;
   private String area;

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>受講生一覧</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>カナ名</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${studentList}">
+    <td th:text="${studentDetail.student.id}">1</td>
+    <td th:text="${studentDetail.student.name}">山田太郎</td>
+    <td th:text="${studentDetail.student.kanaName}">ヤマダタロウ</td>
+    <td th:text="${studentDetail.student.nickname}">たろちゃん</td>
+    <td th:text="${studentDetail.student.email}">taro@example.com</td>
+    <td th:text="${studentDetail.student.area}">東京都</td>
+    <td th:text="${studentDetail.student.age}">25</td>
+    <td th:text="${studentDetail.student.gender}">男性</td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## 概要
- 27_Thymeleafを使ったReadの画面描画処理
- 課題: ブラウザ上に受講生一覧を表示

## 変更内容
- `build.gradle` に Thymeleaf の依存関係を追加
- Student エンティティの furigana → kanaName に変更
- StudentController を @Controller に変更し、Model を使った一覧取得処理を追加
- `studentList.html` を新規作成し、受講生情報をブラウザ表示

## 動作確認
- /studentList にアクセスし、DBに登録済みの受講生一覧が表示されることを確認
<img width="1161" height="515" alt="studentList_ブラウザ" src="https://github.com/user-attachments/assets/97c35436-b736-421d-a80a-eaa3256a13cb" />
