### PR TITLE
feat: 受講生情報削除処理の実装

### DIFF
--- a/src/main/java/raisetech/Student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/Student/management/repository/StudentRepository.java
@@ -12,7 +12,7 @@ import raisetech.Student.management.data.StudentsCourses;
 @Mapper
 public interface StudentRepository {
 
-  @Select("SELECT * FROM students WHERE is_deleted = false")
+  @Select("SELECT * FROM students")
   List<Student> search();
 
   @Select("SELECT * FROM students WHERE id = #{id}")

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -17,6 +17,7 @@
     <th>年齢</th>
     <th>性別</th>
     <th>備考</th>
+    <th>キャンセル</th>
   </tr>
   </thead>
   <tbody>
@@ -33,6 +34,9 @@
     <td th:text="${studentDetail.student.age}">25</td>
     <td th:text="${studentDetail.student.gender}">男性</td>
     <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}" />
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -42,10 +42,14 @@
     <label for="remark">備考:</label>
     <input type="text" id="remark" th:field="*{student.remark}" />
   </div>
+  <div>
+    <label for="isDeleted">キャンセル:</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}" />
+  </div>
   <div th:each="course, stat : *{studentsCourses}">
-    <label for="id"
+    <label for="studentCourseId"
            th:for="studentCourse.[__${stat.index}__].id">受講生コースID: </label>
-    <input type="text" id="id" th:id="studentCourse.[__${stat.index}__].id"
+    <input type="text" id="studentCourseId" th:id="studentCourse.[__${stat.index}__].id"
            th:field="*{studentsCourses[__${stat.index}__].id}" />
     <label for="courseName"
            th:for="studentCourse.[__${stat.index}__].courseName">受講生コース名: </label>


### PR DESCRIPTION
## 概要
- 受講生情報削除処理の実装
  - データベース上の物理削除ではなく、isDeleted フラグで管理
  - 受講生一覧や詳細画面でチェックボックスの状態を確認・変更可能
  - 既存の更新処理 (updateStudent) に統合して、一括で受講生情報と論理削除状態を更新できるように

## 変更内容
- 受講生一覧画面 (studentList.html) の変更
  - 「キャンセル（論理削除）」項目を追加
  - 各受講生の isDeleted の状態をチェックボックスで表示
  - チェックボックスは 編集不可（表示用） として利用
  - 既存の受講生情報（名前、カナ名、メールなど）に加えて、削除状態を一覧画面で確認可能に
- 受講生詳細画面 (updateStudent.html) の変更
  - フォームに「キャンセル（論理削除）」チェックボックスを追加
  - th:field="*{student.deleted}" を使用して Student.isDeleted プロパティとバインド
  - チェックの有無に応じて、受講生の論理削除状態を更新可能
  - 既存の受講生情報（名前、メール、コース情報など）と一緒に編集できるように修正
  - 受講生コースの ID とコース名の入力要素について、id 属性の重複を避けるように修正

## 動作確認
<img width="1185" height="523" alt="受講生一覧_論理削除_キャンセル_チェックボックス" src="https://github.com/user-attachments/assets/89796a03-a4cb-4a1d-b206-5c8720ce1ea0" />
<img width="933" height="663" alt="受講生詳細_論理削除_キャンセル_チェックボックス" src="https://github.com/user-attachments/assets/dce447e6-6b6b-4d56-af18-494f150968cf" />
