### PR TITLE
課題: 入力チェックの追加

### DIFF
--- a/src/main/java/raisetech/Student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/Student/management/controller/StudentController.java
@@ -1,6 +1,8 @@
 package raisetech.Student.management.controller;
 
-import jakarta.validation.constraints.Size;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -45,7 +47,7 @@ public class StudentController {
    * @return 受講生
    */
   @GetMapping("/student/{id}")
-  public StudentDetail getStudent(@PathVariable String id) {
+  public StudentDetail getStudent(@PathVariable @NotBlank @Pattern(regexp = "^\\d+$") String id) {
     return service.searchStudent(id);
   }
 
@@ -56,7 +58,7 @@ public class StudentController {
    * @return 実行結果
    */
   @PostMapping("/registerStudent")
-  public ResponseEntity<StudentDetail> registerStudent(@RequestBody StudentDetail studentDetail) {
+  public ResponseEntity<StudentDetail> registerStudent(@RequestBody @Valid StudentDetail studentDetail) {
     StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
     return ResponseEntity.ok(responseStudentDetail);
   }
@@ -68,7 +70,7 @@ public class StudentController {
    * @return 実行結果
    */
   @PutMapping("/updateStudent")
-  public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
+  public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
     return ResponseEntity.ok("更新処理が成功しました。");
   }

--- a/src/main/java/raisetech/Student/management/data/Student.java
+++ b/src/main/java/raisetech/Student/management/data/Student.java
@@ -1,5 +1,8 @@
 package raisetech.Student.management.data;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,14 +10,30 @@ import lombok.Setter;
 @Setter
 public class Student {
 
+  @Pattern(regexp = "^\\d+$")
   private String id;
+
+  @NotBlank
   private String name;
+
+  @NotBlank
   private String kanaName;
+
+  @NotBlank
   private String nickname;
+
+  @NotBlank
+  @Email
   private String email;
+
+  @NotBlank
   private String area;
+
   private int age;
+
+  @NotBlank
   private String gender;
+
   private String remark;
   private boolean isDeleted;
 }

--- a/src/main/java/raisetech/Student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/Student/management/data/StudentCourse.java
@@ -1,5 +1,6 @@
 package raisetech.Student.management.data;
 
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,7 +11,10 @@ public class StudentCourse {
 
   private String id;
   private String studentId;
+
+  @NotBlank
   private String courseName;
+
   private LocalDateTime courseStartAt;
   private LocalDateTime courseEndAt;
 

--- a/src/main/java/raisetech/Student/management/domain/StudentDetail.java
+++ b/src/main/java/raisetech/Student/management/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.Student.management.domain;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,9 @@ import raisetech.Student.management.data.StudentCourse;
 @AllArgsConstructor
 public class StudentDetail {
 
+  @Valid
   private Student student;
+  @Valid
   private List<StudentCourse> studentCourseList;
 
 }


### PR DESCRIPTION
## 変更内容
- `StudentDetail`に`@Valid`アノテーションを追加し、`student`や`studentCourseList`の中身までバリデーションを可能とする。
- `@GetMapping("/student/{id}")`の`getStudent`メソッドの引数に`@NotBlank @Pattern(regexp = "^\\d+$")`を追加
  - 空でなく、数字であることをチェック
- `Student`と`StudentCourse`のフィールドにアノテーション追加(`@NotBlank`など)
  - 各オブジェクトの`id`関連のフィールドには`@NotBlank`をつけない(登録処理で`id`は空であるため)
  
## 動作確認
- Postmanで更新処理を実行(`gender`の値を空にして)
 
<img width="819" height="711" alt="updateTest_gender_null" src="https://github.com/user-attachments/assets/36aa642f-9929-4c6c-a03a-f7ed7a810607" />

- エラーが出る(`Field error in object 'studentDetail' on field 'student.gender': rejected value [];`, `default message [空白は許可されていません]`)
<img width="1691" height="113" alt="updateTest_gender_null_2" src="https://github.com/user-attachments/assets/cba35a9c-0439-4e1b-8962-a120e1ece2f0" />

