### PR TITLE
42_Controllerのテスト解説とJUnitの機能解説

### DIFF
--- a/src/test/java/raisetech/Student/management/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/Student/management/controller/converter/StudentConverterTest.java
@@ -1,0 +1,78 @@
+package raisetech.Student.management.controller.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import raisetech.Student.management.data.Student;
+import raisetech.Student.management.data.StudentCourse;
+import raisetech.Student.management.domain.StudentDetail;
+
+class StudentConverterTest {
+
+  private StudentConverter sut;
+
+  @BeforeEach
+  void before() {
+    sut = new StudentConverter();
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成できること() {
+    Student student = createStudent();
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId("1");
+    studentCourse.setStudentId("1");
+    studentCourse.setCourseName("Javaコース");
+    studentCourse.setCourseStartAt(LocalDateTime.now());
+    studentCourse.setCourseEndAt(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+    assertThat(actual).hasSize(1);
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEqualTo(studentCourseList);
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡した時に紐づかない受講生コース情報は除外されること() {
+    Student student = createStudent();
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId("1");
+    studentCourse.setStudentId("2");
+    studentCourse.setCourseName("Javaコース");
+    studentCourse.setCourseStartAt(LocalDateTime.now());
+    studentCourse.setCourseEndAt(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+    assertThat(actual).hasSize(1);
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEmpty();
+  }
+
+  private static Student createStudent() {
+    Student student = new Student();
+    student.setId("1");
+    student.setName("山田太郎");
+    student.setKanaName("ヤマダタロウ");
+    student.setNickname("たろちゃん");
+    student.setEmail("taro@example.com");
+    student.setArea("東京都");
+    student.setAge(25);
+    student.setGender("男性");
+    student.setRemark("");
+    student.setDeleted(false);
+    return student;
+  }
+}


### PR DESCRIPTION
## 変更内容
- `StudentConverterTest`の新規作成
  - `受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成できること`と`受講生のリストと受講生コース情報のリストを渡した時に紐づかない受講生コース情報は除外されること`をテスト。
  - 両方のメソッドで共通の情報を`createStudent`としてメソッド抽出